### PR TITLE
Feat: Added Optional Required bag item

### DIFF
--- a/conf/leech.conf.dist
+++ b/conf/leech.conf.dist
@@ -30,3 +30,11 @@ Leech.DungeonsOnly = 1
 #
 
 Leech.Amount = 0.05
+#
+#    Leech.RequiredItemId
+#        Description: Allows setting an item required in bags to activate leech.
+#        Default:     0 - No Item Required
+#                     xxxxx - Specify the item ID
+#
+
+Leech.RequiredItemId = 0

--- a/src/Leech.cpp
+++ b/src/Leech.cpp
@@ -28,6 +28,12 @@ public:
             return;
         }
 
+        uint32 requiredItem = sConfigMgr->GetOption<uint32>("Leech.RequiredItemId", 0u);
+        if (requiredItem != 0 && !(player->HasItemCount(requiredItem, 1, false)))
+        {
+            return;
+        }
+
         auto leechAmount = sConfigMgr->GetOption<float>("Leech.Amount", 0.05f);
         auto bp1 = static_cast<int32>(leechAmount * float(damage));
         player->CastCustomSpell(attacker, SPELL_HEAL, &bp1, nullptr, nullptr, true);


### PR DESCRIPTION
Adding the option to allow server admins to require an item to exist in the player's bag. This acts as an on/off switch without needing to edit the config, or as a way to reward players with the ability to leech via an item.